### PR TITLE
Move parameter calls from constructor into __init__ function

### DIFF
--- a/cordial_manager/scripts/manager.py
+++ b/cordial_manager/scripts/manager.py
@@ -33,20 +33,36 @@ class CordialManager:
 
     def __init__(
             self,
-            aws_voice_name,
-            aws_region_name,
-            viseme_play_speed,
-            min_viseme_duration_in_seconds,
-            delay_to_publish_visemes_in_seconds,
-            delay_to_publish_gestures_in_seconds=None,
-            is_debug=False
+            delay_to_publish_gestures_in_seconds=None
     ):
 
         rospy.init_node(self._NODE_NAME, anonymous=False)
 
-        if type(is_debug) is not bool:
-            raise TypeError("is_debug must be either True or False")
-        self._is_debug = is_debug
+        self._aws_region_name = rospy.get_param(
+            'aws/region_name',
+            'us-west-1'
+        )
+        self._aws_voice_name = rospy.get_param(
+            'cordial/speech/aws/voice_name',
+            'Ivy'
+        )
+        self._viseme_play_speed = rospy.get_param(
+            'cordial/speech/viseme/play_speed',
+            10
+        )
+        self._min_viseme_duration_in_seconds = rospy.get_param(
+            'cordial/speech/viseme/min_duration_in_seconds',
+            0.05
+        )
+        self._delay_to_publish_visemes_in_seconds = rospy.get_param(
+            'cordial/speech/viseme/publish_delay_in_seconds',
+            0.1
+        )
+        self._is_debug = rospy.get_param(
+            'cordial/manager/is_debug',
+            False
+        )
+
         if self._is_debug:
             rospy.loginfo("Running in debug mode")
 
@@ -74,16 +90,12 @@ class CordialManager:
         self._gui_action_client = actionlib.SimpleActionClient(self._ASK_ON_GUI_SERVICE, AskAction)
 
         self._aws_client = AwsPollyClient(
-            voice=aws_voice_name,
-            region=aws_region_name,
+            voice=self._aws_voice_name,
+            region=self._aws_region_name,
         )
 
-        self._viseme_play_speed = viseme_play_speed
-        self._min_viseme_duration_in_seconds = min_viseme_duration_in_seconds
-
-        self._delay_to_publish_visemes_in_seconds = delay_to_publish_visemes_in_seconds
         if delay_to_publish_gestures_in_seconds is None:
-            delay_to_publish_gestures_in_seconds = delay_to_publish_visemes_in_seconds
+            delay_to_publish_gestures_in_seconds = self._delay_to_publish_visemes_in_seconds
         self._delay_to_publish_gestures_in_seconds = delay_to_publish_gestures_in_seconds
 
         self._is_awake = True
@@ -251,12 +263,5 @@ class CordialManager:
 
 if __name__ == '__main__':
 
-    CordialManager(
-        aws_region_name=rospy.get_param('aws/region_name', 'us-west-1'),
-        aws_voice_name=rospy.get_param('cordial/speech/aws/voice_name', 'Ivy'),
-        viseme_play_speed=rospy.get_param('cordial/speech/viseme/play_speed', 10),
-        min_viseme_duration_in_seconds=rospy.get_param('cordial/speech/viseme/min_duration_in_seconds', 0.05),
-        delay_to_publish_visemes_in_seconds=rospy.get_param('cordial/speech/viseme/publish_delay_in_seconds', 0.1),
-        is_debug=rospy.get_param('cordial/manager/is_debug', False)
-    )
+    CordialManager()
     rospy.spin()

--- a/cordial_sound/scripts/wav_file_publisher.py
+++ b/cordial_sound/scripts/wav_file_publisher.py
@@ -11,16 +11,16 @@ from std_msgs.msg import String
 
 class WavFilePublisher:
 
-    def __init__(
-            self,
-            wav_header_length,
-    ):
+    def __init__(self):
 
         rospy.init_node('wav_player', anonymous=True)
+        self._wav_header_length = rospy.get_param(
+            'cordial/sound/wav/header_length',
+            24
+        )
         rospy.Subscriber('cordial/sound/play/file_path/wav', String, self.play_wav_file)
         self._sound_publisher = rospy.Publisher("cordial/sound/play/stream", Sound, queue_size=1)
         self._pyaudio = pyaudio.PyAudio()
-        self._wav_header_length = wav_header_length
 
     def play_wav_file(self, data):
 
@@ -51,7 +51,5 @@ class WavFilePublisher:
 
 if __name__ == '__main__':
 
-    WavFilePublisher(
-        wav_header_length=rospy.get_param('cordial/sound/wav/header_length', 24)
-    )
+    WavFilePublisher()
     rospy.spin()

--- a/cordial_tools/scripts/internet_speed_monitor.py
+++ b/cordial_tools/scripts/internet_speed_monitor.py
@@ -7,18 +7,26 @@ import time
 
 class RosInternetSpeedTester:
 
-    def __init__(self, minutes_before_check, is_run_test_on_init=True):
+    def __init__(self):
         self._speed_tester = speedtest.Speedtest()
 
         rospy.init_node('internet_speed_monitor')
+
+        self._minutes_before_check = int(rospy.get_param(
+            'minutes_before_check_internet_speed', default=20
+        ))
+        self._is_run_test_on_init = rospy.get_param(
+            'is_run_internet_speed_test_on_init', default=True
+        )
+
         rospy.timer.Timer(
             rospy.Duration(
-                secs=minutes_before_check * 60
+                secs=self._minutes_before_check * 60
             ),
             callback=self._log_internet_speed_callback,
         )
 
-        if is_run_test_on_init:
+        if self._is_run_test_on_init:
             self.log_internet_speed()
 
     def log_internet_speed(self):
@@ -57,12 +65,5 @@ class RosInternetSpeedTester:
 
 
 if __name__ == '__main__':
-    RosInternetSpeedTester(
-        minutes_before_check=rospy.get_param(
-            'minutes_before_check_internet_speed', default=20
-        ),
-        is_run_test_on_init=rospy.get_param(
-            'is_run_internet_speed_test_on_init', default=True
-        )
-    )
+    RosInternetSpeedTester()
     rospy.spin()


### PR DESCRIPTION
Fixes #4. Rather than making parameter calls in class constructors, private variables are set by calling `rospy.get_param()` in the `__init__` function. 