### PR TITLE
Add low vision interface

### DIFF
--- a/src/cordial_gui/web/index.html
+++ b/src/cordial_gui/web/index.html
@@ -12,8 +12,7 @@
     <link href="https://fonts.googleapis.com/css?family=B612&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="libs/css/bootstrap.min.css">
     <link rel="stylesheet" href="libs/css/wickedpicker.min.css">
-    <!--<link rel="stylesheet" href="src/css/gui.css">-->
-    <link rel="stylesheet" href="src/css/low_vision_gui.css">
+    <link rel="stylesheet" href="src/css/gui.css">
 
     <title>Cordial Gui</title>
 </head>

--- a/src/cordial_gui/web/index.html
+++ b/src/cordial_gui/web/index.html
@@ -12,7 +12,8 @@
     <link href="https://fonts.googleapis.com/css?family=B612&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="libs/css/bootstrap.min.css">
     <link rel="stylesheet" href="libs/css/wickedpicker.min.css">
-    <link rel="stylesheet" href="src/css/gui.css">
+    <!--<link rel="stylesheet" href="src/css/gui.css">-->
+    <link rel="stylesheet" href="src/css/low_vision_gui.css">
 
     <title>Cordial Gui</title>
 </head>

--- a/src/cordial_gui/web/low_vision.html
+++ b/src/cordial_gui/web/low_vision.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- suppresses favicon error -->
+    <link rel="shortcut icon" href="#" />
+
+    <link href="https://fonts.googleapis.com/css?family=B612&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="libs/css/bootstrap.min.css">
+    <link rel="stylesheet" href="libs/css/wickedpicker.min.css">
+    <link rel="stylesheet" href="src/css/low_vision_gui.css">
+
+    <title>Cordial Gui</title>
+</head>
+
+<body>
+    <div id="top"></div>
+    <div class="background h-100">
+        <div id="black" class="h-100"></div>
+        <div id="col-1" class="container h-100">
+            <div class="row h-100 justify-content-center align-items-center">
+                <div class="col-12">
+                    <div id="col-1-content"></div>
+                    <div id="col-1-input"></div>
+                </div>
+            </div>
+        </div>
+        <div id="col-2" class="container h-100">
+            <div class="row h-100 justify-content-center align-items-center">
+                <div class="col-8">
+                    <div id="col-2-left" class="scroller"></div>
+                </div>
+                <div class="col-4">
+                    <div id="col-2-right" class="scroller"></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- required for ros communications -->
+        <script src="libs/js/eventemitter2.min.js" type="text/javascript"></script>
+        <script src="libs/js/roslib.js" type="text/javascript"></script>
+
+        <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+        <script src="libs/js/jquery.js" type="text/javascript"></script>
+        <script src="libs/js/popper.min.js" type="text/javascript"></script>
+        <script src="libs/js/bootstrap.min.js" type="text/javascript"></script>
+        <script src="libs/js/wickedpicker.js" type="text/javascript"></script>
+
+        <!-- Our source files-->
+        <script src="src/js/display_maker.js" type="text/javascript"></script>
+        <script src="src/js/ros_interface.js" type="text/javascript"></script>
+        <script src="src/js/run.js" type="text/javascript"></script>
+
+</html>

--- a/src/cordial_gui/web/src/css/low_vision_gui.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui.css
@@ -1,0 +1,134 @@
+body,
+p,
+.container,
+.scroller,
+.col-4,
+.col-8,
+.row {
+    padding: 0;
+    margin: 0;
+}
+
+.container {
+    max-width: 100vw;
+}
+
+html,
+body {
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    font-size: 3em;
+    font-weight: bold;
+    font-family: 'B612', sans-serif;
+    text-align: center;
+}
+
+.background {
+    background-color: white;
+    background-blend-mode: lighten;
+    background-size: cover;
+}
+
+input {
+    border-radius: 4vh;
+    padding: 2vh 5vw 2vh 5vw;
+    margin: 2vh;
+    text-align: center;
+    white-space: normal;
+    background: black;
+    color: white;
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+input[type=button] {
+    font-size:1.8em;
+}
+
+input[type=text] {
+    width: 60vw;
+}
+
+
+input.timepicker {
+    width: 40vw;
+    text-align: center;
+}
+
+#black {
+    background-color: black;
+}
+
+#black,
+#col-1,
+#col-2 {
+    display: none;
+}
+
+#col-1-content {
+    padding: 8vh;
+}
+
+#col-1-input {
+    display: inline-flex;
+    padding: 4vh;
+}
+
+.scroller {
+    overflow-y: scroll;
+    max-height: 70vh;
+}
+
+.scroller::-webkit-scrollbar {
+    width: 3vw;
+}
+
+.scroller::-webkit-scrollbar-track {
+    display: none;
+}
+
+.scroller::-webkit-scrollbar-thumb {
+    background: #add8e6;
+    border-radius: 3vw;
+}
+
+.scroller::-webkit-scrollbar-thumb:hover {
+    background: blue;
+}
+
+.slider {
+    -webkit-appearance: none;
+    width: 60vw;
+    height: 4vh;
+    border-radius: 2vh;
+    background: #FFFFFF;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    transition: opacity .2s;
+}
+
+.slider:hover {
+    opacity: 1;
+}
+
+.slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 5vh;
+    height: 5vh;
+    border-radius: 50%;
+    background: #0000A0;
+    cursor: pointer;
+}
+
+.slider::-moz-range-thumb {
+    width: 5vh;
+    height: 5vh;
+    border-radius: 50%;
+    background: #4CAF50;
+    cursor: pointer;
+}

--- a/src/cordial_gui/web/src/css/low_vision_gui.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui.css
@@ -41,11 +41,9 @@ input {
     background: black;
     color: white;
     font-weight: bold;
-    font-size: 1.2em;
 }
 
 input[type=button] {
-    font-size:1.8em;
     padding: 5vh 5vw 5vh 5vw;
 }
 
@@ -71,11 +69,13 @@ input.timepicker {
 
 #col-1-content {
     padding: 8vh;
+    font-size:1.7em;
 }
 
 #col-1-input {
     display: inline-flex;
     padding: 4vh;
+    font-size:2.6em;
 }
 
 .scroller {

--- a/src/cordial_gui/web/src/css/low_vision_gui.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui.css
@@ -46,6 +46,7 @@ input {
 
 input[type=button] {
     font-size:1.8em;
+    padding: 5vh 5vw 5vh 5vw;
 }
 
 input[type=text] {

--- a/src/cordial_gui/web/src/js/display_maker.js
+++ b/src/cordial_gui/web/src/js/display_maker.js
@@ -209,6 +209,27 @@ function _parse_time(t) {
     return d;
 }
 
+// function multiple_choice_prompt(
+//     content,
+//     buttons,
+//     callback_fn,
+//     args = [],
+//     seconds_before_enabling_input = 0
+// ) {
+//     if (args.length > 0) {
+//         alert("No args accepted to multiple choice");
+//     }
+
+//     _two_col_prompt(
+//         content,
+//         _make_buttons(buttons),
+//         _get_pushed_button_value,
+//         undefined,
+//         callback_fn,
+//         seconds_before_enabling_input
+//     );
+// }
+
 function multiple_choice_prompt(
     content,
     buttons,
@@ -220,9 +241,16 @@ function multiple_choice_prompt(
         alert("No args accepted to multiple choice");
     }
 
-    _two_col_prompt(
-        content,
-        _make_buttons(buttons),
+    var parent_selector = "#col-1";
+    var content_selector = "#col-1-content";
+    var input_selector = "#col-1-input";
+
+    $(content_selector).html(_prepare_content(content));
+    $(input_selector).html(_make_buttons(buttons));
+
+    _prompt(
+        parent_selector,
+        input_selector,
         _get_pushed_button_value,
         undefined,
         callback_fn,

--- a/src/cordial_gui/web/src/js/display_maker.js
+++ b/src/cordial_gui/web/src/js/display_maker.js
@@ -209,28 +209,28 @@ function _parse_time(t) {
     return d;
 }
 
-// function multiple_choice_prompt(
-//     content,
-//     buttons,
-//     callback_fn,
-//     args = [],
-//     seconds_before_enabling_input = 0
-// ) {
-//     if (args.length > 0) {
-//         alert("No args accepted to multiple choice");
-//     }
+ function multiple_choice_prompt(
+     content,
+     buttons,
+     callback_fn,
+     args = [],
+     seconds_before_enabling_input = 0
+ ) {
+     if (args.length > 0) {
+         alert("No args accepted to multiple choice");
+     }
 
-//     _two_col_prompt(
-//         content,
-//         _make_buttons(buttons),
-//         _get_pushed_button_value,
-//         undefined,
-//         callback_fn,
-//         seconds_before_enabling_input
-//     );
-// }
+     _two_col_prompt(
+         content,
+         _make_buttons(buttons),
+         _get_pushed_button_value,
+         undefined,
+         callback_fn,
+         seconds_before_enabling_input
+     );
+ }
 
-function multiple_choice_prompt(
+function multiple_choice_prompt_one_col(
     content,
     buttons,
     callback_fn,

--- a/src/cordial_gui/web/src/js/display_maker.js
+++ b/src/cordial_gui/web/src/js/display_maker.js
@@ -209,7 +209,7 @@ function _parse_time(t) {
     return d;
 }
 
- function multiple_choice_prompt(
+function multiple_choice_prompt(
      content,
      buttons,
      callback_fn,

--- a/src/cordial_gui/web/src/js/ros_interface.js
+++ b/src/cordial_gui/web/src/js/ros_interface.js
@@ -133,6 +133,9 @@ function make_display(display_msg) {
         case 'multiple choice':
             multiple_choice_prompt(content, buttons, callback_fn, args, buttons_delay_seconds);
             break;
+        case 'multiple choice one column':
+            multiple_choice_prompt_one_col(content, buttons, callback_fn, args, buttons_delay_seconds);
+            break;
         case 'text entry':
             text_entry_prompt(content, buttons, callback_fn, args, buttons_delay_seconds);
             break;


### PR DESCRIPTION
Fixes #42. I've added an HTMl and CSS file for a low-vision interface. To use the low-vision display, specify "/low_vision.html" when accessing the GUI. I've also added a one-column display option for multiple-choice prompts, where the options are displayed beneath the text instead of to the right. 