### PR TITLE
Stream sound in chunks of 1 sec instead of all at once. fixes #21

### DIFF
--- a/src/cordial/topic_parameters.yaml
+++ b/src/cordial/topic_parameters.yaml
@@ -16,5 +16,7 @@ cordial_say:
 cordial_sound:
   play_wav_topic: cordial/sound/play/file_path/wav
   play_stream_topic: cordial/sound/play/stream
+  sound_listener_sleep_time: 0.05
+  seconds_per_chunk: 1
 cordial_sleep:
   sleep_topic: cordial/sleep

--- a/src/cordial_msgs/msg/Sound.msg
+++ b/src/cordial_msgs/msg/Sound.msg
@@ -1,4 +1,4 @@
-uint8 format
+uint8 audio_format
 uint8 num_channels
 int64 framerate
 uint8[] data

--- a/src/cordial_sound/scripts/sound_listener.py
+++ b/src/cordial_sound/scripts/sound_listener.py
@@ -41,7 +41,8 @@ def play_sound(data):
             output_device_index=SPEAKER_DEVICE_INDEX,
         )
         stream.write(data.data)
-        time.sleep(0.05)
+        time.sleep(float(rospy.get_param(
+            "cordial_sound/sound_listener_sleep_time")))
         stream.stop_stream()
 
         stream.close()

--- a/src/cordial_sound/scripts/sound_listener.py
+++ b/src/cordial_sound/scripts/sound_listener.py
@@ -29,10 +29,8 @@ def play_sound(data):
 
     p = pyaudio.PyAudio()
 
-    """
-    Occasionally pyaudio fails to open correctly.  Online resources said that this was likely because This is an attempt to fix it by closing down the node
-    and restarting the node. 
-    """
+    # Occasionally pyaudio fails to open correctly.  Online resources said that this was likely because This is an attempt to fix it by closing down the node and restarting the node.
+
     try:
         stream = p.open(
             format=data.format,
@@ -43,7 +41,7 @@ def play_sound(data):
             output_device_index=SPEAKER_DEVICE_INDEX,
         )
         stream.write(data.data)
-        time.sleep(1)
+        time.sleep(0.05)
         stream.stop_stream()
 
         stream.close()
@@ -54,8 +52,7 @@ def play_sound(data):
 
 if __name__ == '__main__':
 
-
     rospy.init_node('sound_listener')
-    rospy.Subscriber(rospy.get_param('cordial_sound/play_stream_topic'), Sound, play_sound)
+    rospy.Subscriber(rospy.get_param(
+        'cordial_sound/play_stream_topic'), Sound, play_sound)
     rospy.spin()
-

--- a/src/cordial_sound/scripts/wav_file_publisher.py
+++ b/src/cordial_sound/scripts/wav_file_publisher.py
@@ -4,6 +4,10 @@ import rospy
 import pyaudio
 import numpy as np
 import wave
+from pydub import AudioSegment
+import math
+import os
+import tempfile
 
 from cordial_msgs.msg import Sound
 from std_msgs.msg import String
@@ -18,21 +22,33 @@ class WavFilePublisher:
             'cordial/sound/wav/header_length',
             24
         )
-        rospy.Subscriber(rospy.get_param('cordial_sound/play_wav_topic'), String, self.play_wav_file)
-        self._sound_publisher = rospy.Publisher(rospy.get_param('cordial_sound/play_stream_topic'), Sound, queue_size=1)
+        rospy.Subscriber(rospy.get_param(
+            'cordial_sound/play_wav_topic'), String, self.play_wav_file)
+        self._sound_publisher = rospy.Publisher(rospy.get_param(
+            'cordial_sound/play_stream_topic'), Sound, queue_size=10)
         self._pyaudio = pyaudio.PyAudio()
 
-    def play_wav_file(self, data):
+    def _split_audio_once(self, from_sec, to_sec, audio):
+        t1 = from_sec * 1000  # seconds to milliseconds
+        t2 = to_sec * 1000  # seconds to milliseconds
+        split_audio = audio[t1:t2]
+        return split_audio
 
-        file_path = data.data
+    def split_audio_into_chunks(self, filename, seconds_per_split):
+        audio = AudioSegment.from_wav(filename)
+        total_seconds = math.ceil(audio.duration_seconds)
+        audio_chunks = []
+        for i in range(0, total_seconds, seconds_per_split):
+            split_audio = self._split_audio_once(i, i+seconds_per_split, audio)
+            audio_chunks.append(split_audio)
+            if i == total_seconds - seconds_per_split:
+                rospy.loginfo(
+                    'The audio file splited successfully into chunks')
+        return audio_chunks
 
-        try:
-            wf = wave.open(file_path, 'rb')
-        except IOError:
-            rospy.logerr("Not a valid wav file: '{}'".format(file_path))
-            return
-
-        audio_format = self._pyaudio.get_format_from_width(wf.getsampwidth())
+    def publish_audio_chunk(self, wf, file_path, current_chunk_id):
+        audio_format = self._pyaudio.get_format_from_width(
+            wf.getsampwidth())
         framerate = wf.getframerate()
         num_channels = wf.getnchannels()
 
@@ -45,8 +61,34 @@ class WavFilePublisher:
         sound_msg.framerate = framerate
         sound_msg.data = data
 
-        rospy.loginfo("Publishing sound from '{}'".format(file_path))
+        rospy.loginfo(
+            f"Publishing sound chunk {str(current_chunk_id)}/{str(len(self.audio_chunks))} from '{format(file_path)}'")
         self._sound_publisher.publish(sound_msg)
+
+    def play_wav_file(self, data, seconds_per_split=1):
+
+        file_path = data.data
+
+        try:
+            wf_original = wave.open(file_path, 'rb')
+        except IOError:
+            rospy.logerr("Not a valid wav file: '{}'".format(file_path))
+            return
+
+        # Splitting wav to multiple parts of 1 sec each
+        audio_chunks = self.split_audio_into_chunks(
+            file_path, seconds_per_split=seconds_per_split)
+
+        # Creating a temporary file for the audio
+        temp_audio_file = tempfile.NamedTemporaryFile(suffix='.wav')
+
+        # Publishing each chunk of 1 sec separtely
+        for i, value in enumerate(audio_chunks):
+            value.export(temp_audio_file.name, format="wav")
+
+            wf = wave.open(temp_audio_file.name, 'rb')
+
+            self.publish_audio_chunk(wf, file_path, i)
 
 
 if __name__ == '__main__':

--- a/src/cordial_sound/scripts/wav_file_publisher.py
+++ b/src/cordial_sound/scripts/wav_file_publisher.py
@@ -65,7 +65,7 @@ class WavFilePublisher:
             f"Publishing sound chunk {str(current_chunk_id)}/{str(len(self.audio_chunks))} from '{format(file_path)}'")
         self._sound_publisher.publish(sound_msg)
 
-    def play_wav_file(self, data, seconds_per_split=1):
+    def play_wav_file(self, data, seconds_per_split=int(rospy.get_param("cordial_sound/seconds_per_chunk"))):
 
         file_path = data.data
 

--- a/src/cordial_sound/scripts/wav_file_publisher.py
+++ b/src/cordial_sound/scripts/wav_file_publisher.py
@@ -25,7 +25,7 @@ class WavFilePublisher:
         rospy.Subscriber(rospy.get_param(
             'cordial_sound/play_wav_topic'), String, self.play_wav_file)
         self._sound_publisher = rospy.Publisher(rospy.get_param(
-            'cordial_sound/play_stream_topic'), Sound, queue_size=10)
+            'cordial_sound/play_stream_topic'), Sound, queue_size=1)
         self._pyaudio = pyaudio.PyAudio()
 
     def _split_audio_once(self, from_sec, to_sec, audio):


### PR DESCRIPTION
Sending the audio file in chunks of 1 sec each instead of at once so that it can be interrupted immediately. Also, setting sleep on the listener to 20 Hertz