### PR TITLE
Enable test discovery

### DIFF
--- a/src/cordial_manager/CMakeLists.txt
+++ b/src/cordial_manager/CMakeLists.txt
@@ -7,6 +7,11 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_python_setup()
 
+if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_cordial.test)
+endif()
+
 catkin_package()
 
 include_directories(

--- a/src/cordial_manager/package.xml
+++ b/src/cordial_manager/package.xml
@@ -19,4 +19,6 @@
   <build_export_depend>actionlib</build_export_depend>
 
   <exec_depend>actionlib</exec_depend>
+
+  <test_depend>rostest</test_depend>
 </package>


### PR DESCRIPTION
Fixes #44. Executing `catkin_make run_tests_cordial_manager` in the `catkin_ws` directory will execute `test_cordial.test`, which runs the test files for both `cordial_manager` and `cordial_gui`. 

@audrow, all 16 tests pass on my system, but it would be good to test this out on yours to confirm that this PR introduces working changes. 