### PR TITLE
Update GUI for input-only display

### DIFF
--- a/src/cordial_gui/web/low_vision.html
+++ b/src/cordial_gui/web/low_vision.html
@@ -24,6 +24,7 @@
         <div id="col-1" class="container h-100">
             <div class="row h-100 justify-content-center align-items-center">
                 <div class="col-12">
+                    <div id="col-1-numpad"></div>
                     <div id="col-1-content"></div>
                     <div id="col-1-input"></div>
                 </div>

--- a/src/cordial_gui/web/low_vision_input_only.html
+++ b/src/cordial_gui/web/low_vision_input_only.html
@@ -25,6 +25,7 @@
         <div id="col-1" class="container h-100">
             <div class="row h-100 justify-content-center align-items-center">
                 <div class="col-12">
+                    <div id="col-1-numpad"></div>
                     <div id="col-1-input"></div>
                 </div>
             </div>
@@ -49,5 +50,6 @@
         <script src="src/js/display_maker.js" type="text/javascript"></script>
         <script src="src/js/ros_interface.js" type="text/javascript"></script>
         <script src="src/js/run.js" type="text/javascript"></script>
-
+    </div>
+</body>
 </html>

--- a/src/cordial_gui/web/src/css/low_vision_gui.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui.css
@@ -68,7 +68,7 @@ input.timepicker {
     display: none;
 }
 
-#col-1-content {
+#col-1-content, #col-1-numpad {
     padding: 0.5em;
     font-size: 1.7em;
 }

--- a/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
@@ -20,7 +20,7 @@
 }
 
 #col-1-numpad {
-    padding: 0.5em;
+    padding: 1vw;
     font-size: 1.7em;
 }
 

--- a/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
@@ -1,31 +1,3 @@
-body,
-p,
-.container,
-.scroller,
-.col-4,
-.col-8,
-.row {
-    padding: 0;
-    margin: 0;
-}
-
-.container {
-    max-width: 100vw;
-}
-
-html,
-body {
-    width: 100%;
-    height: 100%;
-}
-
-body {
-    font-size: 2em;
-    font-weight: bold;
-    font-family: 'B612', sans-serif;
-    text-align: center;
-}
-
 .background {
     background-color: white;
     background-blend-mode: lighten;

--- a/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
+++ b/src/cordial_gui/web/src/css/low_vision_gui_input_only.css
@@ -1,3 +1,31 @@
+body,
+p,
+.container,
+.scroller,
+.col-4,
+.col-8,
+.row {
+    padding: 0;
+    margin: 0;
+}
+
+.container {
+    max-width: 100vw;
+}
+
+html,
+body {
+    width: 100%;
+    height: 100%;
+}
+
+body {
+    font-size: 2em;
+    font-weight: bold;
+    font-family: 'B612', sans-serif;
+    text-align: center;
+}
+
 .background {
     background-color: white;
     background-blend-mode: lighten;
@@ -6,7 +34,7 @@
 
 #col-2-right input, #col-1 input {
     width: 70vw;
-    height: 16vh;
+    height: fit-content;
     font-size: 2.5em;
     font-weight: bold;
     font-family: 'B612', sans-serif;
@@ -17,4 +45,20 @@
     color: white;
     margin: 1vh;
     padding: 2px;
+}
+
+#col-1-numpad {
+    padding: 0.5em;
+    font-size: 1.7em;
+}
+
+.numpad-row {
+    padding-bottom: 2%;
+}
+
+.numpad-row > button {
+    color: white;
+    background-color: black;
+    width: 15%;
+    border-radius: 10%;
 }

--- a/src/cordial_gui/web/src/js/display_maker.js
+++ b/src/cordial_gui/web/src/js/display_maker.js
@@ -280,7 +280,7 @@ function numpad_prompt(
     seconds_before_enabling_input = 0
 ) {
     var parent_selector = "#col-1";
-    var content_selector = "#col-1-content";
+    var content_selector = "#col-1-numpad";
     var input_selector = "#col-1-input";
 
     var display_html = _make_keypad_html();


### PR DESCRIPTION
Ensures that buttons expand vertically to fit the contents, and that the number pad display type shows up properly for input-only mode. Here's an example of the button modification (here, it's not vertically centered because it was a screenshot from debug mode):

<img src="https://user-images.githubusercontent.com/55266635/116031255-2678b880-a612-11eb-8ccf-1487cb8c66ba.png" width="250">